### PR TITLE
fix: split macro implementation into separate crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,6 +79,14 @@ name = "unfmt"
 version = "0.1.0"
 dependencies = [
  "bstr",
+ "unfmt_macros",
+]
+
+[[package]]
+name = "unfmt_macros"
+version = "0.1.0"
+dependencies = [
+ "bstr",
  "proc-macro2",
  "quote",
  "syn",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,9 +15,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "proc-macro2"
@@ -30,33 +30,33 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
+checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
 
 [[package]]
 name = "serde"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870026e60fa08c69f064aa766c10f10b1d62db9ccd4d0abb206472bee0ce3b32"
+checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.196"
+version = "1.0.197"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
+checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,16 +10,19 @@ categories = ["no-std", "value-formatting"]
 keywords = ["unformat", "regex"]
 
 [lib]
-proc-macro = true
+path = "./unfmt.rs"
 
-[lints.clippy]
+[workspace]
+members = ["unfmt_macros"]
+
+[workspace.lints.clippy]
 all = "deny"
 pedantic = "deny"
 restriction = "deny"
 nursery = "deny"
 # REASON: We disable them when they are not idiomatic.
 blanket_clippy_restriction_lints = { level = "allow", priority = 1 }
-# REAsON: Not idiomatic.
+# REASON: Not idiomatic.
 implicit_return = { level = "allow", priority = 1 }
 # REASON: False-positives with macros.
 pub_use = { level = "allow", priority = 1 }
@@ -58,6 +61,4 @@ needless_borrowed_reference = { level = "allow", priority = 1 }
 
 [dependencies]
 bstr = "1"
-syn = "2"
-quote = "1"
-proc-macro2 = "1"
+unfmt_macros = { path = "unfmt_macros" }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -1,0 +1,54 @@
+use std::{
+    env::{self, temp_dir},
+    fs::{create_dir_all, write},
+};
+
+#[test]
+fn test_e2e() {
+    let e2e_dir = temp_dir().join("unfmt_e2e");
+    create_dir_all(e2e_dir.join("src")).expect("failed to create temp dir");
+
+    write(
+        e2e_dir.join("src/main.rs"),
+        r#"use unfmt::unformat;fn main() {unformat!("hello {}", "hello world");}"#,
+    )
+    .expect("failed to write file");
+
+    let mut cargo_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    if cfg!(windows) {
+        cargo_dir = cargo_dir.replace("\\", "/");
+    }
+    write(
+        e2e_dir.join("Cargo.toml"),
+        format! { r#"
+[package]
+name = "unfmt_e2e"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies.unfmt]
+path = "{cargo_dir}"
+"#},
+    )
+    .expect("failed to write file");
+
+    let output = std::process::Command::new("cargo")
+        .arg("run")
+        .current_dir(&e2e_dir)
+        .output()
+        .expect("failed to run cargo");
+
+    if !output.status.success() {
+        println!("tempdir: {}", e2e_dir.display());
+        println!(
+            "stderr: {}",
+            std::str::from_utf8(&output.stderr).expect("failed to convert stdout to string")
+        );
+        println!(
+            "stdout: {}",
+            std::str::from_utf8(&output.stdout).expect("failed to convert stdout to string")
+        );
+    }
+
+    assert!(output.status.success());
+}

--- a/unfmt.rs
+++ b/unfmt.rs
@@ -1,0 +1,2 @@
+pub use bstr;
+pub use unfmt_macros::*;

--- a/unfmt_macros/Cargo.toml
+++ b/unfmt_macros/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "unfmt_macros"
+version = "0.1.0"
+edition = "2021"
+description = "A compile-time pattern matching library that reverses the interpolation process of `format!`."
+license = "MIT OR Apache-2.0"
+authors = ["Mathematic Inc"]
+repository = "https://github.com/mathematic-inc/unfmt"
+categories = ["no-std", "value-formatting"]
+keywords = ["unformat", "regex"]
+
+[lib]
+proc-macro = true
+path = "./unfmt_macros.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+bstr = "1"
+syn = "2"
+quote = "1"
+proc-macro2 = "1"

--- a/unfmt_macros/unfmt_macros.rs
+++ b/unfmt_macros/unfmt_macros.rs
@@ -254,8 +254,8 @@ pub fn unformat(input: TokenStream) -> TokenStream {
 
     TokenStream::from(quote! {
         'unformat: {
-            use ::std::str::FromStr;
-            use ::bstr::{ByteSlice, BStr};
+            use ::core::str::FromStr;
+            use ::unfmt::bstr::{ByteSlice, BStr};
             let Some((__unfmt_left, mut __unfmt_byte_text)) = BStr::new(#text).split_once_str(#initial_part) else {
                 break 'unformat None;
             };


### PR DESCRIPTION
Fixed: https://github.com/mathematic-inc/unfmt/issues/12, https://github.com/mathematic-inc/unfmt/pull/13