### PR TITLE
fix: satisfy current clippy lint

### DIFF
--- a/unfmt_macros/unfmt_macros.rs
+++ b/unfmt_macros/unfmt_macros.rs
@@ -228,7 +228,7 @@ pub fn unformat(input: TokenStream) -> TokenStream {
             })
             .collect::<Vec<_>>();
 
-        capture_indices.sort_by(|&index_a, &index_b| index_a.cmp(&index_b));
+        capture_indices.sort_by_key(|&index| index);
 
         capture_indices
             .into_iter()


### PR DESCRIPTION
Replace the manual comparator with Clippy’s behavior-preserving `sort_by_key` form.

Checks:
- `cargo fmt --all -- --check`
- `cargo clippy --all-targets -- -D warnings`
- `cargo test`