### PR TITLE
chore(hk): ignore changelogs

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -4,6 +4,7 @@ import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtin
 
 min_hk_version = "1.56.1"
 hide_warnings = List("missing-profiles")
+exclude = List("**/CHANGELOG.md")
 
 local generatedFiles =
   List(


### PR DESCRIPTION
Exclude release-managed changelog files at the root hk configuration level so generated release notes do not block repository checks.

Validation:
- `hk check --all --slow`
- hk Markdown plan: 2 selected files from 4 Markdown files, proving both changelogs are excluded
- `git diff --check`