### PR TITLE
fix: declare Rust 1.81 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  msrv:
+    name: Rust 1.81.0
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install Rust 1.81.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: "1.81.0"
+      - name: Check MSRV
+        run: rustup run 1.81.0 cargo check --locked --workspace --all-features --all-targets
+      - name: Test MSRV
+        run: rustup run 1.81.0 cargo test --locked --workspace --all-features --all-targets
+
   ci:
     name: CI
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "unfmt"
 version = "0.3.1"
 edition = "2021"
+rust-version = "1.81"
 description = "A compile-time pattern matching library that reverses the interpolation process of `format!`."
 license = "Apache-2.0"
 authors = ["Mathematic Inc"]

--- a/unfmt_macros/Cargo.toml
+++ b/unfmt_macros/Cargo.toml
@@ -2,6 +2,7 @@
 name = "unfmt_macros"
 version = "0.3.1"
 edition = "2021"
+rust-version = "1.81"
 description = "A compile-time pattern matching library that reverses the interpolation process of `format!`."
 license = "Apache-2.0"
 authors = ["Mathematic Inc"]


### PR DESCRIPTION
## Summary
- declare Rust 1.81 uniformly for unfmt and unfmt_macros
- add an exact Rust 1.81.0 CI job covering the full workspace and all targets
- compile and run the complete test suite at the MSRV

## Verification
- Rust 1.81.0 cargo check --locked --workspace --all-features --all-targets
- Rust 1.81.0 cargo test --locked --workspace --all-features --all-targets (10 passed)
- exhaustive hk check --all --slow