### PR TITLE
fix(ci): harden release workflows and repository checks

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,55 +4,33 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.2.0)"
+        description: Existing release tag
         required: true
         type: string
+
+concurrency:
+  group: release-notes-${{ inputs.tag }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
-concurrency:
-  group: release-notes-${{ github.event.inputs.tag }}
-  cancel-in-progress: true
-
 jobs:
   enhance:
-    name: Enhance release notes with Claude
+    name: Update release notes
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 5
+    environment: release
     permissions:
       contents: write
-      id-token: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Write release notes with Claude
-        uses: anthropics/claude-code-action@1f291e1cfe0f5fc21db2aef19af844591600ade7 # v1.0.206
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: --allowedTools "Bash(git log:*),Bash(git describe:*),Read,Write"
-          prompt: |
-            Write an exciting, polished GitHub release body for unfmt ${{ inputs.tag }} and save it to `release-notes.md`.
-
-            unfmt is a Rust library providing inverse string formatting — it extracts typed values from formatted strings using the same format spec as `format!`. Think of it as `format!` in reverse: `unformat!("{} + {} = {}", "1 + 2 = 3")` yields `("1", "2", "3")`.
-
-            Steps:
-            1. Run `git describe --tags --abbrev=0 HEAD^` to get the previous tag, then run `git log <previous-tag>..HEAD --oneline` to see all commits in this release.
-            2. Read `unfmt.rs` and `unfmt_macros/` source files to understand the API surface.
-            3. Write the release body to `release-notes.md`. It should:
-               - Open with an enthusiastic one-paragraph summary of what's new or why this release is exciting.
-               - Have clearly labelled sections (e.g. **✨ New Features**, **🐛 Bug Fixes**, **⚡ Improvements**) — only include sections that actually have content.
-               - For any significant new feature, include a short Rust example snippet showing it in action.
-               - End with an installation snippet (add `unfmt = "${{ inputs.tag }}"` to `Cargo.toml`, stripping the leading `v`).
-               - Be written in an upbeat, developer-friendly tone — celebrate the work!
-            Do NOT publish it yourself — a subsequent step will do that.
-
-      - name: Publish release notes
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ inputs.tag }}
-          body_path: release-notes.md
+      - name: Generate notes for the existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: |
+          gh release view "$RELEASE_TAG" --repo "$GH_REPO" >/dev/null
+          gh api --method POST "repos/$GH_REPO/releases/generate-notes" \
+            -f tag_name="$RELEASE_TAG" --jq .body > release-notes.md
+          gh release edit "$RELEASE_TAG" --repo "$GH_REPO" --notes-file release-notes.md

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   release-please:
+    environment: release
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/hk.pkl
+++ b/hk.pkl
@@ -183,8 +183,7 @@ local checks = new Mapping<String, Step> {
   // Rust.
   ["cargo-lockfile"] = new Step {
     glob = List("Cargo.toml", "Cargo.lock", "**/Cargo.toml")
-    check =
-      "worktree=$(mktemp -d) && trap 'rm -rf \"$worktree\"' EXIT && git ls-files -z | tar --null -T - -cf - | tar -xf - -C \"$worktree\" && cargo generate-lockfile --manifest-path \"$worktree/Cargo.toml\" && diff -u Cargo.lock \"$worktree/Cargo.lock\""
+    check = "cargo metadata --locked --format-version 1 --all-features > /dev/null"
     profiles = slow
   }
   ["cargo-fmt"] = (Builtins.cargo_fmt) {


### PR DESCRIPTION
Validate the committed Cargo lockfile without requiring the latest registry versions. Protect release automation with the release environment and generate release notes through GitHub's native API.

Validation: actionlint passed locally. Rust 1.81.0, Analyze (actions), Check, Analyze (rust), CI, CodeQL all passed in GitHub at commit 15e110edcfe532fdbe282533a9f7ec6424a148f7.
